### PR TITLE
Check name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Get a status badge for all GitHub Action runs on the `master` branch of a reposi
 ![badge](https://action-badges.now.sh/JasonEtco/example-repo)
 ```
 
-Specify a workflow with the `workflow` query parameter:
+Specify an action with the `action` query parameter:
 
 ```md
-![badge](https://action-badges.now.sh/JasonEtco/example-repo?workflow=test-on-push)
+![badge](https://action-badges.now.sh/JasonEtco/example-repo?action=mpn%20test)
 ```
 
 **Note:** This service only works for public repositories! It cannot read the status of your private repos.

--- a/lib/get-check-suites.js
+++ b/lib/get-check-suites.js
@@ -10,13 +10,13 @@ const GITHUB_ACTIONS_APP_ID = 15368
  * @param {object} options
  * @param {string} options.owner
  * @param {string} options.repo
- * @param {string} options.suite
+ * @param {string} options.action
  * @param {string} [options.ref='master']
  * @returns {object[]}
  */
-module.exports = async function getCheckSuites ({ owner, repo, suite, ref = 'master' }) {
+module.exports = async function getCheckSuites ({ owner, repo, action, ref = 'master' }) {
   const params = { owner, repo, ref, app_id: GITHUB_ACTIONS_APP_ID }
-  if (suite) params.check_suite = suite
+  if (action) params.check_name = action
   const result = await octokit.checks.listSuitesForRef(params)
   return result.data.check_suites
 }

--- a/lib/get-status.js
+++ b/lib/get-status.js
@@ -17,5 +17,5 @@ module.exports = function getStatus (checkSuites) {
     return 'neutral'
   }
 
-  return 'unknown'
+  return 'mixed'
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const makeBadge = require('./make-badge')
 module.exports = async (req, res) => {
   const { pathname, query } = parse(req.url, true)
   const [, owner, repo] = pathname.split('/')
-  const suite = query.workflow
-  const badge = await makeBadge({ owner, repo, suite })
+  const { action } = query
+  const badge = await makeBadge({ owner, repo, action })
   res.end(badge)
 }

--- a/lib/make-badge.js
+++ b/lib/make-badge.js
@@ -5,7 +5,8 @@ const getStatus = require('./get-status')
 const COLORS = {
   green: ['passing'],
   gray: ['neutral', 'unknown'],
-  red: ['failing', 'error']
+  red: ['failing', 'error'],
+  orange: ['mixed']
 }
 
 /**
@@ -16,10 +17,10 @@ const COLORS = {
  * @param {string} options.suite - A specific check suite to query for
  * @returns {string} - SVG code string
  */
-module.exports = async function makeBadge ({ owner, repo, suite }) {
+module.exports = async function makeBadge (options) {
   let status
   try {
-    const checkSuites = await getCheckSuites({ owner, repo, suite })
+    const checkSuites = await getCheckSuites(options)
     status = getStatus(checkSuites)
   } catch (err) {
     if (err.status === 404) {

--- a/lib/make-badge.js
+++ b/lib/make-badge.js
@@ -14,7 +14,7 @@ const COLORS = {
  * @param {object} options
  * @param {string} options.owner - Owner of the repository
  * @param {string} options.repo - Name of the repository
- * @param {string} options.suite - A specific check suite to query for
+ * @param {string} options.action - A specific action to query for
  * @returns {string} - SVG code string
  */
 module.exports = async function makeBadge (options) {

--- a/tests/get-check-suites.test.js
+++ b/tests/get-check-suites.test.js
@@ -35,14 +35,14 @@ describe('getCheckSuites', () => {
 
   it('returns an array of check suites with a specific suite', async () => {
     nocked
-      .get(/\/repos\/JasonEtco\/example\/commits\/master\/check-suites\?.*check_suite=my-workflow/)
-      .reply(200, { check_suites: [1, 2] })
+      .get(/\/repos\/JasonEtco\/example\/commits\/master\/check-suites\?.*check_name=my-action/)
+      .reply(200, { check_suites: [1] })
     const checkSuites = await getCheckSuites({
       owner: 'JasonEtco',
       repo: 'example',
-      suite: 'my-workflow'
+      action: 'my-action'
     })
     expect(nocked.isDone()).toBe(true)
-    expect(checkSuites).toEqual([1, 2])
+    expect(checkSuites).toEqual([1])
   })
 })

--- a/tests/get-status.test.js
+++ b/tests/get-status.test.js
@@ -16,8 +16,8 @@ describe('getStatus', () => {
     expect(actual).toBe('neutral')
   })
 
-  it('returns `unknown` if it gets confused', () => {
+  it('returns `mixed` if it gets confused', () => {
     const actual = getStatus([{ conclusion: 'pizza' }])
-    expect(actual).toBe('unknown')
+    expect(actual).toBe('mixed')
   })
 })


### PR DESCRIPTION
Turns out theres no way to get the conclusion of a particular workflow 😭 all the check suites are named the same, and the workflow name isn't present on the check suite object.

Instead, this PR adds the `action` query param, so we can specify a particular action to look for. It's not nearly as useful, but it's something. I'll look into why the check suite responses don't come with the name of the workflow.