### PR TITLE
@octokit/request

### DIFF
--- a/lib/get-check-suites.js
+++ b/lib/get-check-suites.js
@@ -1,6 +1,4 @@
-const octokit = require('@octokit/rest')({
-  auth: process.env.GITHUB_TOKEN
-})
+const request = require('@octokit/request')
 
 // The unique ID for the production GitHub Actions app
 const GITHUB_ACTIONS_APP_ID = 15368
@@ -17,6 +15,12 @@ const GITHUB_ACTIONS_APP_ID = 15368
 module.exports = async function getCheckSuites ({ owner, repo, action, ref = 'master' }) {
   const params = { owner, repo, ref, app_id: GITHUB_ACTIONS_APP_ID }
   if (action) params.check_name = action
-  const result = await octokit.checks.listSuitesForRef(params)
+  const result = await request('GET /repos/:owner/:repo/commits/:ref/check-suites', {
+    ...params,
+    headers: {
+      accept: 'application/vnd.github.antiope-preview+json',
+      authorization: `token ${process.env.GITHUB_TOKEN}`
+    }
+  })
   return result.data.check_suites
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,22 +222,6 @@
         "universal-user-agent": "^2.0.1"
       }
     },
-    "@octokit/rest": {
-      "version": "16.16.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.16.3.tgz",
-      "integrity": "sha512-8v5xyqXZwQbQ1WsTLU3G25nAlcKYEgIXzDeqLgTFpbzzJXcey0C8Mcs/LZiAgU8dDINZtO2dAPgd1cVKgK9DQw==",
-      "requires": {
-        "@octokit/request": "2.4.0",
-        "before-after-hook": "^1.2.0",
-        "btoa-lite": "^1.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "lodash.uniq": "^4.5.0",
-        "octokit-pagination-methods": "^1.1.0",
-        "universal-user-agent": "^2.0.0",
-        "url-template": "^2.0.8"
-      }
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -721,11 +705,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "before-after-hook": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
-      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w=="
-    },
     "binary-extensions": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
@@ -854,11 +833,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "btoa-lite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4335,26 +4309,11 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4853,11 +4812,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "octokit-pagination-methods": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/JasonEtco/action-badges#readme",
   "dependencies": {
     "@octokit/request": "^2.4.0",
-    "@octokit/rest": "^16.16.3",
     "badgen": "^2.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR swaps out `@octokit/rest` for `@octokit/request` - this'll make for a faster deploy and probably some performance improvements, since instantiating the `octokit` instance means registering a whole bunch of methods. Since we're only make one API call, we don't need the whole library. Shoutout @gr2m for making stuff like this possible ✨ 